### PR TITLE
Use longs instead of integer

### DIFF
--- a/model-common/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDTO.java
+++ b/model-common/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDTO.java
@@ -8,7 +8,7 @@ import lombok.Value;
 @Value
 @Builder
 public class PersonDTO {
-  private Integer id;
+  private Long id;
   @NonNull private String username;
   @NonNull private String lastName;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationAllowedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationAllowedEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class ApplicationAllowedEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationCancelledEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationCancelledEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class ApplicationCancelledEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationCreatedFromSickNoteEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationCreatedFromSickNoteEventDTO.java
@@ -17,7 +17,7 @@ public class ApplicationCreatedFromSickNoteEventDTO {
 
     @NonNull private UUID id;
 
-    @NonNull private Integer sourceId;
+    @NonNull private Long sourceId;
 
     @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationPersonDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/ApplicationPersonDTO.java
@@ -9,6 +9,6 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @Jacksonized
 public class ApplicationPersonDTO {
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
 }

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/VacationTypeDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/application/VacationTypeDTO.java
@@ -9,7 +9,7 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @Jacksonized
 public class VacationTypeDTO {
-  @NonNull Integer sourceId;
+  @NonNull Long sourceId;
   @NonNull String category;
   boolean requiresApprovalToApply;
   boolean requiresApprovalToCancel;

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonCreatedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonCreatedEventDTO.java
@@ -16,7 +16,7 @@ public class PersonCreatedEventDTO {
   @NonNull private UUID id;
   @NonNull private Instant createdAt;
   @NonNull private String tenantId;
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
   @NonNull private String lastName;
   @NonNull private String firstName;
@@ -25,7 +25,7 @@ public class PersonCreatedEventDTO {
 
   public static PersonCreatedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,
@@ -37,7 +37,7 @@ public class PersonCreatedEventDTO {
 
   public static PersonCreatedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDeletedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDeletedEventDTO.java
@@ -16,7 +16,7 @@ public class PersonDeletedEventDTO {
   @NonNull private UUID id;
   @NonNull private Instant createdAt;
   @NonNull private String tenantId;
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
   @NonNull private String lastName;
   @NonNull private String firstName;
@@ -25,7 +25,7 @@ public class PersonDeletedEventDTO {
 
   public static PersonDeletedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,
@@ -37,7 +37,7 @@ public class PersonDeletedEventDTO {
 
   public static PersonDeletedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDisabledEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDisabledEventDTO.java
@@ -17,7 +17,7 @@ public class PersonDisabledEventDTO {
   @NonNull private UUID id;
   @NonNull private Instant createdAt;
   @NonNull private String tenantId;
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
   @NonNull private String lastName;
   @NonNull private String firstName;
@@ -26,7 +26,7 @@ public class PersonDisabledEventDTO {
 
   public static PersonDisabledEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,
@@ -36,7 +36,7 @@ public class PersonDisabledEventDTO {
 
   public static PersonDisabledEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonUpdatedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonUpdatedEventDTO.java
@@ -16,7 +16,7 @@ public class PersonUpdatedEventDTO {
   @NonNull private UUID id;
   @NonNull private Instant createdAt;
   @NonNull private String tenantId;
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
   @NonNull private String lastName;
   @NonNull private String firstName;
@@ -25,7 +25,7 @@ public class PersonUpdatedEventDTO {
 
   public static PersonUpdatedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,
@@ -37,7 +37,7 @@ public class PersonUpdatedEventDTO {
 
   public static PersonUpdatedEventDTO create(
       String tenantId,
-      Integer personId,
+      Long personId,
       String username,
       String lastName,
       String firstName,

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteCancelledEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteCancelledEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class SickNoteCancelledEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteConvertedToApplicationEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteConvertedToApplicationEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class SickNoteConvertedToApplicationEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteCreatedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteCreatedEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class SickNoteCreatedEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNotePersonDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNotePersonDTO.java
@@ -9,6 +9,6 @@ import lombok.extern.jackson.Jacksonized;
 @Builder
 @Jacksonized
 public class SickNotePersonDTO {
-  @NonNull private Integer personId;
+  @NonNull private Long personId;
   @NonNull private String username;
 }

--- a/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteUpdatedEventDTO.java
+++ b/model-events/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/sicknote/SickNoteUpdatedEventDTO.java
@@ -15,7 +15,7 @@ import lombok.extern.jackson.Jacksonized;
 public class SickNoteUpdatedEventDTO {
   @NonNull private UUID id;
 
-  @NonNull private Integer sourceId;
+  @NonNull private Long sourceId;
 
   @NonNull private Instant createdAt;
 

--- a/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonCreatedEventDTOTest.java
+++ b/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonCreatedEventDTOTest.java
@@ -12,7 +12,7 @@ class PersonCreatedEventDTOTest {
     final PersonCreatedEventDTO event =
         PersonCreatedEventDTO.create(
             "default",
-            1,
+            1L,
             "61f886fd-e07c-4cc3-add0-d869520172e1",
             "Muster",
             "Marlene",

--- a/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDeletedEventDTOTest.java
+++ b/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDeletedEventDTOTest.java
@@ -11,7 +11,7 @@ class PersonDeletedEventDTOTest {
     final PersonDeletedEventDTO event =
         PersonDeletedEventDTO.create(
             "default",
-            1,
+            1L,
             "61f886fd-e07c-4cc3-add0-d869520172e1",
             "Muster",
             "Marlene",

--- a/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDisabledEventDTOTest.java
+++ b/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonDisabledEventDTOTest.java
@@ -11,7 +11,7 @@ class PersonDisabledEventDTOTest {
     final PersonDisabledEventDTO event =
         PersonDisabledEventDTO.create(
             "default",
-            1,
+            1L,
             "61f886fd-e07c-4cc3-add0-d869520172e1",
             "Muster",
             "Marlene",

--- a/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonUpdatedEventDTOTest.java
+++ b/model-events/src/test/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonUpdatedEventDTOTest.java
@@ -12,7 +12,7 @@ class PersonUpdatedEventDTOTest {
     final PersonUpdatedEventDTO event =
         PersonUpdatedEventDTO.create(
             "default",
-            1,
+            1L,
             "61f886fd-e07c-4cc3-add0-d869520172e1",
             "Muster",
             "Marlene",

--- a/service/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonServiceExtension.java
+++ b/service/src/main/java/de/focus_shift/urlaubsverwaltung/extension/api/person/PersonServiceExtension.java
@@ -28,15 +28,15 @@ public interface PersonServiceExtension {
    * @param person the person to be deleted
    * @param signedInUserId the personId who wants to delete the given person
    */
-  void delete(PersonDTO person, Integer signedInUserId);
+  void delete(PersonDTO person, Long signedInUserId);
 
   /**
    * finds a {@link PersonDTO} in the database by its primary key.
    *
-   * @param id Integer the id of the person
+   * @param id Long the id of the person
    * @return optional {@link PersonDTO} for the given id
    */
-  Optional<PersonDTO> getPersonById(Integer id);
+  Optional<PersonDTO> getPersonById(Long id);
 
   /**
    * finds a {@link PersonDTO} in the database by username.


### PR DESCRIPTION
Based on the uv since version 5.x the ids are now longs.

We can also use this in the 4.x by converting integers to longs, so we do not loose any information.

<!--

Thanks for contributing.
Please review the following notes before submitting you pull request.

Please look for other issues or pull requests which already work on this topic. Is somebody already on it? Do you need to synchronize?

# Security Vulnerabilities

🛑 STOP! 🛑 If your contribution fixes a security vulnerability, please do not submit it.
Instead, please write an E-Mail to to one of the maintainer with all the information
to recreate the security vulnerability.

# Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes.

If they:
 🐞 fix a bug, please describe the broken behaviour and how the changes fix it.
    Please label with 'type: bug' and 'status: new'
    
 🎁 make an enhancement, please describe the new functionality and why you believe it's useful.
    Please label with 'type: enhancement' and 'status: new'
 
If your pull request relates to any existing issues,
please reference them by using the issue number prefixed with #.

-->
